### PR TITLE
persisting tokens in the session

### DIFF
--- a/lib/demo_elixir_phoenix_web/controllers/page_controller.ex
+++ b/lib/demo_elixir_phoenix_web/controllers/page_controller.ex
@@ -28,6 +28,9 @@ defmodule DemoElixirPhoenixWeb.PageController do
 
     {conn, client} = KindeClientSDK.get_token(conn)
 
+    conn = put_session(conn, :access_token, client.access_token)
+    conn = put_session(conn, :refresh_token, client.refresh_token)
+
     render(conn, "index.html", response: nil)
   end
 
@@ -73,6 +76,9 @@ defmodule DemoElixirPhoenixWeb.PageController do
 
   def log_out(conn, _params) do
     conn = KindeClientSDK.logout(conn)
+
+    conn = delete_session(conn, :access_token)
+    conn = delete_session(conn, :refresh_token)
 
     render(conn, "index.html", response: nil)
   end

--- a/lib/demo_elixir_phoenix_web/plugs/check_auth.ex
+++ b/lib/demo_elixir_phoenix_web/plugs/check_auth.ex
@@ -1,0 +1,20 @@
+defmodule DemoElixirPhoenixWeb.Plugs.CheckAuth do
+  import Plug.Conn
+  alias KindeClientSDK
+
+  def init(default), do: default
+
+  def call(conn, _opts) do
+    access_token = get_session(conn, :access_token)
+    refresh_token = get_session(conn, :refresh_token)
+
+    if access_token && refresh_token do
+      conn = KindeClientSDK.init_with_tokens(conn, access_token, refresh_token)
+      conn
+    else
+      conn
+      |> Phoenix.Controller.redirect(to: "/log-in")
+      |> halt()
+    end
+  end
+end

--- a/lib/demo_elixir_phoenix_web/router.ex
+++ b/lib/demo_elixir_phoenix_web/router.ex
@@ -9,15 +9,19 @@ defmodule DemoElixirPhoenixWeb.Router do
     plug(:put_secure_browser_headers)
   end
 
+
+  pipeline :authenticated do
+    plug DemoElixirPhoenixWeb.Plugs.CheckAuth
+  end
+
   pipeline :api do
     plug(:accepts, ["json"])
   end
 
   scope "/", DemoElixirPhoenixWeb do
-    pipe_through(:browser)
+    pipe_through([:browser, :authenticated])
 
     get("/", PageController, :start)
-    get("/log-in", PageController, :index)
     get("/callback", PageController, :callback)
     get("/log-out", PageController, :log_out)
     get("/logout", PageController, :logout)
@@ -29,10 +33,16 @@ defmodule DemoElixirPhoenixWeb.Router do
     get("/user", PageController, :get_user)
     get("/organization", PageController, :get_user_organizations)
     get("/token", PageController, :tokens)
+    get("/helper_methods", PageController, :helper_methods)
+  end
+
+   scope "/", DemoElixirPhoenixWeb do
+    pipe_through(:browser)
+
+    get("/log-in", PageController, :index)
     get("/pkce-reg", PageController, :pkce_reg)
     get("/pkce-callback", PageController, :pkce_callack)
     get("/token-endpoint", PageController, :token_endpoint)
-    get("/helper_methods", PageController, :helper_methods)
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
# Explain your changes

1. CheckAuth plug checks if the access_token and refresh_token are stored in the session.
2. If tokens are found, the SDK is initialized with the init_with_tokens/3 function, which has been added to the KindeClientSDK
3. If tokens are missing, the plug redirects the user

